### PR TITLE
Persist workspace creation and list workspaces

### DIFF
--- a/apps/web/app/api/workspaces/[workspaceId]/email-accounts/[emailAccountId]/route.ts
+++ b/apps/web/app/api/workspaces/[workspaceId]/email-accounts/[emailAccountId]/route.ts
@@ -1,0 +1,133 @@
+import { auth } from "@/app/api/auth/[...nextauth]/auth";
+import prisma from "@/utils/prisma";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const updateEmailAccountSchema = z.object({
+  name: z.string().trim().min(1).max(80).optional(),
+  email: z
+    .string()
+    .trim()
+    .email()
+    .max(255)
+    .transform((email) => email.toLowerCase())
+    .optional(),
+});
+
+async function canManageWorkspace(workspaceId: string, userId: string) {
+  const membership = await prisma.membership.findFirst({
+    where: {
+      organizationId: workspaceId,
+      userId,
+    },
+  });
+
+  return membership?.role === "OWNER" || membership?.role === "ADMIN";
+}
+
+async function getEmailAccount(workspaceId: string, emailAccountId: string) {
+  return prisma.emailAccount.findFirst({
+    where: {
+      id: emailAccountId,
+      organizationId: workspaceId,
+    },
+    select: {
+      id: true,
+      email: true,
+    },
+  });
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { workspaceId: string; emailAccountId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  if (!(await canManageWorkspace(params.workspaceId, session.user.id))) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const targetEmailAccount = await getEmailAccount(
+    params.workspaceId,
+    params.emailAccountId,
+  );
+  if (!targetEmailAccount) {
+    return NextResponse.json(
+      { error: "Email account not found" },
+      { status: 404 },
+    );
+  }
+
+  const parsed = updateEmailAccountSchema.safeParse(await request.json());
+  if (!parsed.success || (!parsed.data.name && !parsed.data.email)) {
+    return NextResponse.json(
+      { error: "Invalid email account payload" },
+      { status: 400 },
+    );
+  }
+
+  if (parsed.data.email && parsed.data.email !== targetEmailAccount.email) {
+    const existingEmailAccount = await prisma.emailAccount.findFirst({
+      where: {
+        organizationId: params.workspaceId,
+        email: parsed.data.email,
+        NOT: { id: targetEmailAccount.id },
+      },
+    });
+    if (existingEmailAccount) {
+      return NextResponse.json(
+        { error: "Email account already exists in this workspace" },
+        { status: 409 },
+      );
+    }
+  }
+
+  const emailAccount = await prisma.emailAccount.update({
+    where: { id: targetEmailAccount.id },
+    data: parsed.data,
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  });
+
+  return NextResponse.json({ emailAccount });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { workspaceId: string; emailAccountId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  if (!(await canManageWorkspace(params.workspaceId, session.user.id))) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const targetEmailAccount = await getEmailAccount(
+    params.workspaceId,
+    params.emailAccountId,
+  );
+  if (!targetEmailAccount) {
+    return NextResponse.json(
+      { error: "Email account not found" },
+      { status: 404 },
+    );
+  }
+
+  await prisma.emailAccount.delete({
+    where: { id: targetEmailAccount.id },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/workspaces/[workspaceId]/email-accounts/route.ts
+++ b/apps/web/app/api/workspaces/[workspaceId]/email-accounts/route.ts
@@ -1,0 +1,120 @@
+import { auth } from "@/app/api/auth/[...nextauth]/auth";
+import prisma from "@/utils/prisma";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const emailAccountSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+  email: z
+    .string()
+    .trim()
+    .email()
+    .max(255)
+    .transform((email) => email.toLowerCase()),
+});
+
+async function getWorkspaceMembership(workspaceId: string, userId: string) {
+  return prisma.membership.findFirst({
+    where: {
+      organizationId: workspaceId,
+      userId,
+    },
+  });
+}
+
+async function canManageWorkspace(workspaceId: string, userId: string) {
+  const membership = await getWorkspaceMembership(workspaceId, userId);
+  return membership?.role === "OWNER" || membership?.role === "ADMIN";
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { workspaceId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const membership = await getWorkspaceMembership(
+    params.workspaceId,
+    session.user.id,
+  );
+  if (!membership) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const emailAccounts = await prisma.emailAccount.findMany({
+    where: { organizationId: params.workspaceId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return NextResponse.json({ emailAccounts });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { workspaceId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  if (!(await canManageWorkspace(params.workspaceId, session.user.id))) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const parsed = emailAccountSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid email account payload" },
+      { status: 400 },
+    );
+  }
+
+  const accountCount = await prisma.emailAccount.count({
+    where: { organizationId: params.workspaceId },
+  });
+  if (accountCount >= 10) {
+    return NextResponse.json(
+      { error: "A workspace can have up to 10 email accounts" },
+      { status: 400 },
+    );
+  }
+
+  const existingEmailAccount = await prisma.emailAccount.findFirst({
+    where: {
+      organizationId: params.workspaceId,
+      email: parsed.data.email,
+    },
+  });
+  if (existingEmailAccount) {
+    return NextResponse.json(
+      { error: "Email account already exists in this workspace" },
+      { status: 409 },
+    );
+  }
+
+  const emailAccount = await prisma.emailAccount.create({
+    data: {
+      organizationId: params.workspaceId,
+      name: parsed.data.name,
+      email: parsed.data.email,
+    },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  });
+
+  return NextResponse.json({ emailAccount }, { status: 201 });
+}

--- a/apps/web/app/api/workspaces/[workspaceId]/members/[memberId]/route.ts
+++ b/apps/web/app/api/workspaces/[workspaceId]/members/[memberId]/route.ts
@@ -1,0 +1,125 @@
+import { auth } from "@/app/api/auth/[...nextauth]/auth";
+import prisma from "@/utils/prisma";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const updateMemberSchema = z.object({
+  role: z.enum(["ADMIN", "USER"]),
+});
+
+async function getOwnerMembership(workspaceId: string, userId: string) {
+  return prisma.membership.findFirst({
+    where: {
+      organizationId: workspaceId,
+      userId,
+      role: "OWNER",
+    },
+  });
+}
+
+async function getTargetMembership(workspaceId: string, memberId: string) {
+  return prisma.membership.findFirst({
+    where: {
+      id: memberId,
+      organizationId: workspaceId,
+    },
+    select: {
+      id: true,
+      role: true,
+      userId: true,
+    },
+  });
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { workspaceId: string; memberId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  if (!(await getOwnerMembership(params.workspaceId, session.user.id))) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const targetMembership = await getTargetMembership(
+    params.workspaceId,
+    params.memberId,
+  );
+  if (!targetMembership) {
+    return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+  if (targetMembership.role === "OWNER") {
+    return NextResponse.json(
+      { error: "Owner role cannot be changed" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = updateMemberSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid member payload" },
+      { status: 400 },
+    );
+  }
+
+  const member = await prisma.membership.update({
+    where: { id: targetMembership.id },
+    data: { role: parsed.data.role },
+    select: {
+      id: true,
+      role: true,
+      invitedName: true,
+      invitedEmail: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          image: true,
+        },
+      },
+    },
+  });
+
+  return NextResponse.json({ member });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { workspaceId: string; memberId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  if (!(await getOwnerMembership(params.workspaceId, session.user.id))) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const targetMembership = await getTargetMembership(
+    params.workspaceId,
+    params.memberId,
+  );
+  if (!targetMembership) {
+    return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+  if (targetMembership.role === "OWNER") {
+    return NextResponse.json(
+      { error: "Owner membership cannot be removed" },
+      { status: 400 },
+    );
+  }
+
+  await prisma.membership.delete({
+    where: { id: targetMembership.id },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/workspaces/[workspaceId]/members/route.ts
+++ b/apps/web/app/api/workspaces/[workspaceId]/members/route.ts
@@ -1,0 +1,128 @@
+import { auth } from "@/app/api/auth/[...nextauth]/auth";
+import prisma from "@/utils/prisma";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const inviteMemberSchema = z.object({
+  name: z.string().trim().max(80).optional(),
+  email: z.string().trim().email().max(255),
+  role: z.enum(["ADMIN", "USER"]).default("USER"),
+});
+
+async function getWorkspaceMembership(workspaceId: string, userId: string) {
+  return prisma.membership.findFirst({
+    where: {
+      organizationId: workspaceId,
+      userId,
+    },
+  });
+}
+
+async function canManageWorkspace(workspaceId: string, userId: string) {
+  const membership = await getWorkspaceMembership(workspaceId, userId);
+  return membership?.role === "OWNER" || membership?.role === "ADMIN";
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { workspaceId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const membership = await getWorkspaceMembership(
+    params.workspaceId,
+    session.user.id,
+  );
+  if (!membership) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const members = await prisma.membership.findMany({
+    where: { organizationId: params.workspaceId },
+    select: {
+      id: true,
+      role: true,
+      invitedName: true,
+      invitedEmail: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          image: true,
+        },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+
+  return NextResponse.json({ members });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { workspaceId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  if (!(await canManageWorkspace(params.workspaceId, session.user.id))) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const parsed = inviteMemberSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid member invite payload" },
+      { status: 400 },
+    );
+  }
+
+  const existingMembership = await prisma.membership.findFirst({
+    where: {
+      organizationId: params.workspaceId,
+      OR: [
+        { invitedEmail: parsed.data.email },
+        { user: { email: parsed.data.email } },
+      ],
+    },
+  });
+  if (existingMembership) {
+    return NextResponse.json(
+      { error: "Member already belongs to this workspace" },
+      { status: 409 },
+    );
+  }
+
+  const member = await prisma.membership.create({
+    data: {
+      organizationId: params.workspaceId,
+      role: parsed.data.role,
+      invitedName: parsed.data.name || null,
+      invitedEmail: parsed.data.email,
+    },
+    select: {
+      id: true,
+      role: true,
+      invitedName: true,
+      invitedEmail: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          image: true,
+        },
+      },
+    },
+  });
+
+  return NextResponse.json({ member }, { status: 201 });
+}

--- a/apps/web/app/api/workspaces/[workspaceId]/members/route.ts
+++ b/apps/web/app/api/workspaces/[workspaceId]/members/route.ts
@@ -5,7 +5,12 @@ import { z } from "zod";
 
 const inviteMemberSchema = z.object({
   name: z.string().trim().max(80).optional(),
-  email: z.string().trim().email().max(255),
+  email: z
+    .string()
+    .trim()
+    .email()
+    .max(255)
+    .transform((email) => email.toLowerCase()),
   role: z.enum(["ADMIN", "USER"]).default("USER"),
 });
 

--- a/apps/web/app/api/workspaces/[workspaceId]/route.ts
+++ b/apps/web/app/api/workspaces/[workspaceId]/route.ts
@@ -1,0 +1,59 @@
+import { auth } from "@/app/api/auth/[...nextauth]/auth";
+import prisma from "@/utils/prisma";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const updateWorkspaceSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+  image: z.string().trim().url().optional().nullable(),
+});
+
+async function canManageWorkspace(workspaceId: string, userId: string) {
+  const membership = await prisma.membership.findFirst({
+    where: {
+      organizationId: workspaceId,
+      userId,
+    },
+    select: { role: true },
+  });
+
+  return membership?.role === "OWNER" || membership?.role === "ADMIN";
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { workspaceId: string } },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  if (!(await canManageWorkspace(params.workspaceId, session.user.id))) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  const parsed = updateWorkspaceSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid workspace payload" },
+      { status: 400 },
+    );
+  }
+
+  const workspace = await prisma.organization.update({
+    where: { id: params.workspaceId },
+    data: {
+      name: parsed.data.name,
+      image: parsed.data.image || null,
+    },
+    select: {
+      id: true,
+      name: true,
+      image: true,
+    },
+  });
+
+  return NextResponse.json({ workspace });
+}

--- a/apps/web/app/api/workspaces/route.ts
+++ b/apps/web/app/api/workspaces/route.ts
@@ -6,6 +6,15 @@ import { z } from "zod";
 const createWorkspaceSchema = z.object({
   name: z.string().trim().min(1).max(80),
   image: z.string().url().optional().nullable(),
+  emailAccounts: z
+    .array(
+      z.object({
+        name: z.string().trim().min(1).max(80),
+        email: z.string().trim().email().max(255),
+      }),
+    )
+    .max(10)
+    .optional(),
 });
 
 export async function GET() {
@@ -64,6 +73,14 @@ export async function POST(request: Request) {
     data: {
       name: parsed.data.name,
       image: parsed.data.image || null,
+      emailAccounts: parsed.data.emailAccounts?.length
+        ? {
+            create: parsed.data.emailAccounts.map((emailAccount) => ({
+              name: emailAccount.name,
+              email: emailAccount.email,
+            })),
+          }
+        : undefined,
       membership: {
         create: {
           role: "OWNER",

--- a/apps/web/app/api/workspaces/route.ts
+++ b/apps/web/app/api/workspaces/route.ts
@@ -1,0 +1,97 @@
+import { auth } from "@/app/api/auth/[...nextauth]/auth";
+import prisma from "@/utils/prisma";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const createWorkspaceSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+  image: z.string().url().optional().nullable(),
+});
+
+export async function GET() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const memberships = await prisma.membership.findMany({
+    where: { userId: session.user.id },
+    include: {
+      organization: {
+        include: {
+          emailAccounts: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+            orderBy: { createdAt: "asc" },
+          },
+        },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+
+  return NextResponse.json({
+    workspaces: memberships.map((membership) => ({
+      id: membership.organization.id,
+      name: membership.organization.name,
+      image: membership.organization.image,
+      role: membership.role,
+      emailAccounts: membership.organization.emailAccounts,
+    })),
+  });
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const parsed = createWorkspaceSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid workspace payload" },
+      { status: 400 },
+    );
+  }
+
+  const workspace = await prisma.organization.create({
+    data: {
+      name: parsed.data.name,
+      image: parsed.data.image || null,
+      membership: {
+        create: {
+          role: "OWNER",
+          userId: session.user.id,
+        },
+      },
+    },
+    include: {
+      emailAccounts: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+    },
+  });
+
+  return NextResponse.json(
+    {
+      workspace: {
+        id: workspace.id,
+        name: workspace.name,
+        image: workspace.image,
+        role: "OWNER",
+        emailAccounts: workspace.emailAccounts,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/apps/web/app/api/workspaces/route.ts
+++ b/apps/web/app/api/workspaces/route.ts
@@ -6,6 +6,16 @@ import { z } from "zod";
 const createWorkspaceSchema = z.object({
   name: z.string().trim().min(1).max(80),
   image: z.string().url().optional().nullable(),
+  invitedMembers: z
+    .array(
+      z.object({
+        name: z.string().trim().max(80).optional(),
+        email: z.string().trim().email().max(255),
+        role: z.enum(["ADMIN", "USER"]).default("USER"),
+      }),
+    )
+    .max(10)
+    .optional(),
   emailAccounts: z
     .array(
       z.object({
@@ -29,6 +39,23 @@ export async function GET() {
     include: {
       organization: {
         include: {
+          membership: {
+            select: {
+              id: true,
+              role: true,
+              invitedName: true,
+              invitedEmail: true,
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  image: true,
+                },
+              },
+            },
+            orderBy: { id: "asc" },
+          },
           emailAccounts: {
             select: {
               id: true,
@@ -49,6 +76,7 @@ export async function GET() {
       name: membership.organization.name,
       image: membership.organization.image,
       role: membership.role,
+      members: membership.organization.membership,
       emailAccounts: membership.organization.emailAccounts,
     })),
   });
@@ -82,13 +110,36 @@ export async function POST(request: Request) {
           }
         : undefined,
       membership: {
-        create: {
-          role: "OWNER",
-          userId: session.user.id,
-        },
+        create: [
+          {
+            role: "OWNER",
+            userId: session.user.id,
+          },
+          ...(parsed.data.invitedMembers ?? []).map((invitedMember) => ({
+            role: invitedMember.role,
+            invitedName: invitedMember.name || null,
+            invitedEmail: invitedMember.email,
+          })),
+        ],
       },
     },
     include: {
+      membership: {
+        select: {
+          id: true,
+          role: true,
+          invitedName: true,
+          invitedEmail: true,
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              image: true,
+            },
+          },
+        },
+      },
       emailAccounts: {
         select: {
           id: true,
@@ -106,6 +157,7 @@ export async function POST(request: Request) {
         name: workspace.name,
         image: workspace.image,
         role: "OWNER",
+        members: workspace.membership,
         emailAccounts: workspace.emailAccounts,
       },
     },

--- a/apps/web/app/api/workspaces/route.ts
+++ b/apps/web/app/api/workspaces/route.ts
@@ -10,20 +10,41 @@ const createWorkspaceSchema = z.object({
     .array(
       z.object({
         name: z.string().trim().max(80).optional(),
-        email: z.string().trim().email().max(255),
+        email: z
+          .string()
+          .trim()
+          .email()
+          .max(255)
+          .transform((email) => email.toLowerCase()),
         role: z.enum(["ADMIN", "USER"]).default("USER"),
       }),
     )
     .max(10)
+    .refine(
+      (members) =>
+        new Set(members.map((member) => member.email)).size === members.length,
+      "Invited members must have unique email addresses",
+    )
     .optional(),
   emailAccounts: z
     .array(
       z.object({
         name: z.string().trim().min(1).max(80),
-        email: z.string().trim().email().max(255),
+        email: z
+          .string()
+          .trim()
+          .email()
+          .max(255)
+          .transform((email) => email.toLowerCase()),
       }),
     )
     .max(10)
+    .refine(
+      (accounts) =>
+        new Set(accounts.map((account) => account.email)).size ===
+        accounts.length,
+      "Email accounts must have unique email addresses",
+    )
     .optional(),
 });
 

--- a/apps/web/components/mail/components/account-switcher.tsx
+++ b/apps/web/components/mail/components/account-switcher.tsx
@@ -25,11 +25,24 @@ export function AccountSwitcher({
   accounts,
 }: AccountSwitcherProps) {
   const [selectedAccount, setSelectedAccount] = React.useState<string>(
-    accounts[0].email,
+    accounts[0]?.email || "",
+  );
+  const selectedAccountDetails = accounts.find(
+    (account) => account.email === selectedAccount,
   );
 
+  React.useEffect(() => {
+    if (!accounts.some((account) => account.email === selectedAccount)) {
+      setSelectedAccount(accounts[0]?.email || "");
+    }
+  }, [accounts, selectedAccount]);
+
+  if (!accounts.length) {
+    return null;
+  }
+
   return (
-    <Select defaultValue={selectedAccount} onValueChange={setSelectedAccount}>
+    <Select value={selectedAccount} onValueChange={setSelectedAccount}>
       <SelectTrigger
         className={cn(
           "flex items-center gap-2 [&>span]:line-clamp-1 [&>span]:flex [&>span]:w-full [&>span]:items-center [&>span]:gap-1 [&>span]:truncate [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0",
@@ -39,12 +52,9 @@ export function AccountSwitcher({
         aria-label="Select account"
       >
         <SelectValue placeholder="Select an account">
-          {accounts.find((account) => account.email === selectedAccount)?.icon}
+          {selectedAccountDetails?.icon}
           <span className={cn("ml-2", isCollapsed && "hidden")}>
-            {
-              accounts.find((account) => account.email === selectedAccount)
-                ?.label
-            }
+            {selectedAccountDetails?.label}
           </span>
         </SelectValue>
       </SelectTrigger>

--- a/apps/web/components/mail/components/mail.tsx
+++ b/apps/web/components/mail/components/mail.tsx
@@ -76,12 +76,27 @@ interface MailProps {
   navCollapsedSize: number;
 }
 
+interface WorkspaceResponse {
+  workspaces: {
+    id: string;
+    name: string;
+    emailAccounts: {
+      id: string;
+      name: string;
+      email: string;
+    }[];
+  }[];
+}
+
 export function Mail({
   accounts,
   defaultLayout = [225, 440, 655],
   defaultCollapsed = false,
   navCollapsedSize,
 }: MailProps) {
+  const { data: workspacesData } =
+    useSWR<WorkspaceResponse>("/api/workspaces");
+
   const {
     data: threadsData,
     error: threadsError,
@@ -126,6 +141,8 @@ export function Mail({
   const [file, setFile] = React.useState<File | undefined>();
   const [isUploading, setIsUploading] = React.useState(false);
   const [workspaceName, setWorkspaceName] = React.useState("");
+  const [emailAccountName, setEmailAccountName] = React.useState("");
+  const [emailAccountEmail, setEmailAccountEmail] = React.useState("");
   const [workspaceError, setWorkspaceError] = React.useState<string | null>(
     null,
   );
@@ -140,6 +157,18 @@ export function Mail({
   const { mutate } = useSWRConfig();
 
   const mail = useAtomValue(configAtom);
+
+  const workspaceAccounts =
+    workspacesData?.workspaces.flatMap((workspace) =>
+      workspace.emailAccounts.map((emailAccount) => ({
+        label: emailAccount.name || workspace.name,
+        email: emailAccount.email,
+        icon: <MessagesSquare className="h-4 w-4" />,
+      })),
+    ) ?? [];
+  const visibleAccounts = workspaceAccounts.length
+    ? workspaceAccounts
+    : accounts;
 
   React.useEffect(() => {
     if (threadsData) {
@@ -282,6 +311,34 @@ export function Mail({
                   }}
                 />
               </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="flex flex-col space-y-2">
+                  <Label>Email account name</Label>
+                  <Input
+                    type="text"
+                    name="emailAccountName"
+                    placeholder="Shared inbox"
+                    value={emailAccountName}
+                    onChange={(event) => {
+                      setEmailAccountName(event.target.value);
+                      setWorkspaceError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex flex-col space-y-2">
+                  <Label>Email account address</Label>
+                  <Input
+                    type="email"
+                    name="emailAccountEmail"
+                    placeholder="team@example.com"
+                    value={emailAccountEmail}
+                    onChange={(event) => {
+                      setEmailAccountEmail(event.target.value);
+                      setWorkspaceError(null);
+                    }}
+                  />
+                </div>
+              </div>
               {workspaceError ? (
                 <DialogDescription className="text-sm text-red-500">
                   {workspaceError}
@@ -304,6 +361,20 @@ export function Mail({
                       return;
                     }
 
+                    const accountName = emailAccountName.trim();
+                    const accountEmail = emailAccountEmail.trim();
+                    if (accountName && !accountEmail) {
+                      setWorkspaceError("Email account address is required.");
+                      return;
+                    }
+                    if (
+                      accountEmail &&
+                      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(accountEmail)
+                    ) {
+                      setWorkspaceError("Enter a valid email account address.");
+                      return;
+                    }
+
                     setWorkspaceError(null);
                     setIsUploading(true);
                     let image: string | undefined;
@@ -322,7 +393,18 @@ export function Mail({
                     const response = await fetch("/api/workspaces", {
                       method: "POST",
                       headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({ name, image }),
+                      body: JSON.stringify({
+                        name,
+                        image,
+                        emailAccounts: accountEmail
+                          ? [
+                              {
+                                name: accountName || accountEmail,
+                                email: accountEmail,
+                              },
+                            ]
+                          : undefined,
+                      }),
                     });
 
                     if (!response.ok) {
@@ -333,6 +415,8 @@ export function Mail({
 
                     await mutate("/api/workspaces");
                     setWorkspaceName("");
+                    setEmailAccountName("");
+                    setEmailAccountEmail("");
                     setFile(undefined);
                     setIsUploading(false);
                     setCreateWorkspaceOpen(false);
@@ -370,7 +454,10 @@ export function Mail({
               isCollapsed ? "h-[52px] flex-col" : "px-2",
             )}
           >
-            <AccountSwitcher isCollapsed={isCollapsed} accounts={accounts} />
+            <AccountSwitcher
+              isCollapsed={isCollapsed}
+              accounts={visibleAccounts}
+            />
           </div>
           <Separator />
           <div className="flex h-[calc(100vh-52px)] flex-col justify-between">

--- a/apps/web/components/mail/components/mail.tsx
+++ b/apps/web/components/mail/components/mail.tsx
@@ -100,6 +100,17 @@ interface WorkspaceResponse {
   }[];
 }
 
+type WorkspaceEmailAccountDraft = {
+  name: string;
+  email: string;
+};
+
+type InvitedMemberDraft = {
+  name: string;
+  email: string;
+  role: "ADMIN" | "USER";
+};
+
 export function Mail({
   accounts,
   defaultLayout = [225, 440, 655],
@@ -153,13 +164,12 @@ export function Mail({
   const [file, setFile] = React.useState<File | undefined>();
   const [isUploading, setIsUploading] = React.useState(false);
   const [workspaceName, setWorkspaceName] = React.useState("");
-  const [emailAccountName, setEmailAccountName] = React.useState("");
-  const [emailAccountEmail, setEmailAccountEmail] = React.useState("");
-  const [invitedMemberName, setInvitedMemberName] = React.useState("");
-  const [invitedMemberEmail, setInvitedMemberEmail] = React.useState("");
-  const [invitedMemberRole, setInvitedMemberRole] = React.useState<
-    "ADMIN" | "USER"
-  >("USER");
+  const [emailAccountDrafts, setEmailAccountDrafts] = React.useState<
+    WorkspaceEmailAccountDraft[]
+  >([{ name: "", email: "" }]);
+  const [invitedMemberDrafts, setInvitedMemberDrafts] = React.useState<
+    InvitedMemberDraft[]
+  >([{ name: "", email: "", role: "USER" }]);
   const [workspaceError, setWorkspaceError] = React.useState<string | null>(
     null,
   );
@@ -186,6 +196,28 @@ export function Mail({
   const visibleAccounts = workspaceAccounts.length
     ? workspaceAccounts
     : accounts;
+  const updateEmailAccountDraft = (
+    index: number,
+    updates: Partial<WorkspaceEmailAccountDraft>,
+  ) => {
+    setEmailAccountDrafts((drafts) =>
+      drafts.map((draft, draftIndex) =>
+        draftIndex === index ? { ...draft, ...updates } : draft,
+      ),
+    );
+    setWorkspaceError(null);
+  };
+  const updateInvitedMemberDraft = (
+    index: number,
+    updates: Partial<InvitedMemberDraft>,
+  ) => {
+    setInvitedMemberDrafts((drafts) =>
+      drafts.map((draft, draftIndex) =>
+        draftIndex === index ? { ...draft, ...updates } : draft,
+      ),
+    );
+    setWorkspaceError(null);
+  };
 
   React.useEffect(() => {
     if (threadsData) {
@@ -299,7 +331,7 @@ export function Mail({
           open={createWorkspaceOpen}
           onOpenChange={setCreateWorkspaceOpen}
         >
-          <DialogContent className="sm:max-w-[625px]">
+          <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[625px]">
             <DialogHeader>
               <DialogTitle className="pb-2 font-cal text-xl font-bold">
                 Create Workspace
@@ -328,78 +360,159 @@ export function Mail({
                   }}
                 />
               </div>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <div className="flex flex-col space-y-2">
-                  <Label>Email account name</Label>
-                  <Input
-                    type="text"
-                    name="emailAccountName"
-                    placeholder="Shared inbox"
-                    value={emailAccountName}
-                    onChange={(event) => {
-                      setEmailAccountName(event.target.value);
-                      setWorkspaceError(null);
-                    }}
-                  />
-                </div>
-                <div className="flex flex-col space-y-2">
-                  <Label>Email account address</Label>
-                  <Input
-                    type="email"
-                    name="emailAccountEmail"
-                    placeholder="team@example.com"
-                    value={emailAccountEmail}
-                    onChange={(event) => {
-                      setEmailAccountEmail(event.target.value);
-                      setWorkspaceError(null);
-                    }}
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-                <div className="flex flex-col space-y-2">
-                  <Label>Invite name</Label>
-                  <Input
-                    type="text"
-                    name="invitedMemberName"
-                    placeholder="Alex Morgan"
-                    value={invitedMemberName}
-                    onChange={(event) => {
-                      setInvitedMemberName(event.target.value);
-                      setWorkspaceError(null);
-                    }}
-                  />
-                </div>
-                <div className="flex flex-col space-y-2">
-                  <Label>Invite email</Label>
-                  <Input
-                    type="email"
-                    name="invitedMemberEmail"
-                    placeholder="alex@example.com"
-                    value={invitedMemberEmail}
-                    onChange={(event) => {
-                      setInvitedMemberEmail(event.target.value);
-                      setWorkspaceError(null);
-                    }}
-                  />
-                </div>
-                <div className="flex flex-col space-y-2">
-                  <Label>Role</Label>
-                  <select
-                    name="invitedMemberRole"
-                    className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
-                    value={invitedMemberRole}
-                    onChange={(event) => {
-                      setInvitedMemberRole(
-                        event.target.value as "ADMIN" | "USER",
-                      );
-                      setWorkspaceError(null);
-                    }}
+              <div className="space-y-3">
+                {emailAccountDrafts.map((emailAccount, index) => (
+                  <div
+                    key={`email-account-${index}`}
+                    className="grid grid-cols-1 gap-4 sm:grid-cols-[1fr_1fr_auto]"
                   >
-                    <option value="USER">User</option>
-                    <option value="ADMIN">Admin</option>
-                  </select>
-                </div>
+                    <div className="flex flex-col space-y-2">
+                      <Label>Email account name</Label>
+                      <Input
+                        type="text"
+                        name={`emailAccountName-${index}`}
+                        placeholder="Shared inbox"
+                        value={emailAccount.name}
+                        onChange={(event) =>
+                          updateEmailAccountDraft(index, {
+                            name: event.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="flex flex-col space-y-2">
+                      <Label>Email account address</Label>
+                      <Input
+                        type="email"
+                        name={`emailAccountEmail-${index}`}
+                        placeholder="team@example.com"
+                        value={emailAccount.email}
+                        onChange={(event) =>
+                          updateEmailAccountDraft(index, {
+                            email: event.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="flex items-end">
+                      <Button
+                        size="icon"
+                        variant="secondary"
+                        onClick={() => {
+                          setEmailAccountDrafts((drafts) =>
+                            drafts.length === 1
+                              ? [{ name: "", email: "" }]
+                              : drafts.filter(
+                                  (_draft, draftIndex) => draftIndex !== index,
+                                ),
+                          );
+                          setWorkspaceError(null);
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        <span className="sr-only">Remove email account</span>
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+                <Button
+                  variant="secondary"
+                  onClick={() =>
+                    setEmailAccountDrafts((drafts) => [
+                      ...drafts,
+                      { name: "", email: "" },
+                    ])
+                  }
+                  disabled={emailAccountDrafts.length >= 10}
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add email account
+                </Button>
+              </div>
+              <div className="space-y-3">
+                {invitedMemberDrafts.map((invitedMember, index) => (
+                  <div
+                    key={`invited-member-${index}`}
+                    className="grid grid-cols-1 gap-4 sm:grid-cols-[1fr_1fr_120px_auto]"
+                  >
+                    <div className="flex flex-col space-y-2">
+                      <Label>Invite name</Label>
+                      <Input
+                        type="text"
+                        name={`invitedMemberName-${index}`}
+                        placeholder="Alex Morgan"
+                        value={invitedMember.name}
+                        onChange={(event) =>
+                          updateInvitedMemberDraft(index, {
+                            name: event.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="flex flex-col space-y-2">
+                      <Label>Invite email</Label>
+                      <Input
+                        type="email"
+                        name={`invitedMemberEmail-${index}`}
+                        placeholder="alex@example.com"
+                        value={invitedMember.email}
+                        onChange={(event) =>
+                          updateInvitedMemberDraft(index, {
+                            email: event.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="flex flex-col space-y-2">
+                      <Label>Role</Label>
+                      <select
+                        name={`invitedMemberRole-${index}`}
+                        className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        value={invitedMember.role}
+                        onChange={(event) =>
+                          updateInvitedMemberDraft(index, {
+                            role: event.target.value as "ADMIN" | "USER",
+                          })
+                        }
+                      >
+                        <option value="USER">User</option>
+                        <option value="ADMIN">Admin</option>
+                      </select>
+                    </div>
+                    <div className="flex items-end">
+                      <Button
+                        size="icon"
+                        variant="secondary"
+                        onClick={() => {
+                          setInvitedMemberDrafts((drafts) =>
+                            drafts.length === 1
+                              ? [{ name: "", email: "", role: "USER" }]
+                              : drafts.filter(
+                                  (_draft, draftIndex) => draftIndex !== index,
+                                ),
+                          );
+                          setWorkspaceError(null);
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        <span className="sr-only">Remove invite</span>
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+                <Button
+                  variant="secondary"
+                  onClick={() =>
+                    setInvitedMemberDrafts((drafts) => [
+                      ...drafts,
+                      { name: "", email: "", role: "USER" },
+                    ])
+                  }
+                  disabled={invitedMemberDrafts.length >= 10}
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add invite
+                </Button>
               </div>
               {workspaceError ? (
                 <DialogDescription className="text-sm text-red-500">
@@ -423,30 +536,82 @@ export function Mail({
                       return;
                     }
 
-                    const accountName = emailAccountName.trim();
-                    const accountEmail = emailAccountEmail.trim();
-                    const inviteName = invitedMemberName.trim();
-                    const inviteEmail = invitedMemberEmail.trim();
-                    if (accountName && !accountEmail) {
+                    const emailAccounts = emailAccountDrafts
+                      .map((emailAccount) => ({
+                        name: emailAccount.name.trim(),
+                        email: emailAccount.email.trim(),
+                      }))
+                      .filter(
+                        (emailAccount) =>
+                          emailAccount.name || emailAccount.email,
+                      );
+                    const invitedMembers = invitedMemberDrafts
+                      .map((invitedMember) => ({
+                        name: invitedMember.name.trim(),
+                        email: invitedMember.email.trim(),
+                        role: invitedMember.role,
+                      }))
+                      .filter(
+                        (invitedMember) =>
+                          invitedMember.name || invitedMember.email,
+                      );
+
+                    if (
+                      emailAccounts.some(
+                        (emailAccount) => !emailAccount.email,
+                      )
+                    ) {
                       setWorkspaceError("Email account address is required.");
                       return;
                     }
                     if (
-                      accountEmail &&
-                      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(accountEmail)
+                      emailAccounts.some(
+                        (emailAccount) =>
+                          !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(
+                            emailAccount.email,
+                          ),
+                      )
                     ) {
-                      setWorkspaceError("Enter a valid email account address.");
+                      setWorkspaceError("Enter valid email account addresses.");
                       return;
                     }
-                    if (inviteName && !inviteEmail) {
+                    if (
+                      new Set(
+                        emailAccounts.map((emailAccount) =>
+                          emailAccount.email.toLowerCase(),
+                        ),
+                      ).size !== emailAccounts.length
+                    ) {
+                      setWorkspaceError("Email account addresses must be unique.");
+                      return;
+                    }
+                    if (
+                      invitedMembers.some(
+                        (invitedMember) => !invitedMember.email,
+                      )
+                    ) {
                       setWorkspaceError("Invite email address is required.");
                       return;
                     }
                     if (
-                      inviteEmail &&
-                      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inviteEmail)
+                      invitedMembers.some(
+                        (invitedMember) =>
+                          !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(
+                            invitedMember.email,
+                          ),
+                      )
                     ) {
-                      setWorkspaceError("Enter a valid invite email address.");
+                      setWorkspaceError("Enter valid invite email addresses.");
+                      return;
+                    }
+                    if (
+                      new Set(
+                        invitedMembers.map((invitedMember) =>
+                          invitedMember.email.toLowerCase(),
+                        ),
+                      ).size !== invitedMembers.length
+                    ) {
+                      setWorkspaceError("Invite email addresses must be unique.");
                       return;
                     }
 
@@ -471,22 +636,18 @@ export function Mail({
                       body: JSON.stringify({
                         name,
                         image,
-                        emailAccounts: accountEmail
-                          ? [
-                              {
-                                name: accountName || accountEmail,
-                                email: accountEmail,
-                              },
-                            ]
+                        emailAccounts: emailAccounts.length
+                          ? emailAccounts.map((emailAccount) => ({
+                              name: emailAccount.name || emailAccount.email,
+                              email: emailAccount.email,
+                            }))
                           : undefined,
-                        invitedMembers: inviteEmail
-                          ? [
-                              {
-                                name: inviteName || undefined,
-                                email: inviteEmail,
-                                role: invitedMemberRole,
-                              },
-                            ]
+                        invitedMembers: invitedMembers.length
+                          ? invitedMembers.map((invitedMember) => ({
+                              name: invitedMember.name || undefined,
+                              email: invitedMember.email,
+                              role: invitedMember.role,
+                            }))
                           : undefined,
                       }),
                     });
@@ -499,11 +660,10 @@ export function Mail({
 
                     await mutate("/api/workspaces");
                     setWorkspaceName("");
-                    setEmailAccountName("");
-                    setEmailAccountEmail("");
-                    setInvitedMemberName("");
-                    setInvitedMemberEmail("");
-                    setInvitedMemberRole("USER");
+                    setEmailAccountDrafts([{ name: "", email: "" }]);
+                    setInvitedMemberDrafts([
+                      { name: "", email: "", role: "USER" },
+                    ]);
                     setFile(undefined);
                     setIsUploading(false);
                     setCreateWorkspaceOpen(false);

--- a/apps/web/components/mail/components/mail.tsx
+++ b/apps/web/components/mail/components/mail.tsx
@@ -80,6 +80,18 @@ interface WorkspaceResponse {
   workspaces: {
     id: string;
     name: string;
+    members: {
+      id: string;
+      role: "OWNER" | "ADMIN" | "USER";
+      invitedName: string | null;
+      invitedEmail: string | null;
+      user: {
+        id: string;
+        name: string | null;
+        email: string | null;
+        image: string | null;
+      } | null;
+    }[];
     emailAccounts: {
       id: string;
       name: string;
@@ -143,6 +155,11 @@ export function Mail({
   const [workspaceName, setWorkspaceName] = React.useState("");
   const [emailAccountName, setEmailAccountName] = React.useState("");
   const [emailAccountEmail, setEmailAccountEmail] = React.useState("");
+  const [invitedMemberName, setInvitedMemberName] = React.useState("");
+  const [invitedMemberEmail, setInvitedMemberEmail] = React.useState("");
+  const [invitedMemberRole, setInvitedMemberRole] = React.useState<
+    "ADMIN" | "USER"
+  >("USER");
   const [workspaceError, setWorkspaceError] = React.useState<string | null>(
     null,
   );
@@ -339,6 +356,51 @@ export function Mail({
                   />
                 </div>
               </div>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div className="flex flex-col space-y-2">
+                  <Label>Invite name</Label>
+                  <Input
+                    type="text"
+                    name="invitedMemberName"
+                    placeholder="Alex Morgan"
+                    value={invitedMemberName}
+                    onChange={(event) => {
+                      setInvitedMemberName(event.target.value);
+                      setWorkspaceError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex flex-col space-y-2">
+                  <Label>Invite email</Label>
+                  <Input
+                    type="email"
+                    name="invitedMemberEmail"
+                    placeholder="alex@example.com"
+                    value={invitedMemberEmail}
+                    onChange={(event) => {
+                      setInvitedMemberEmail(event.target.value);
+                      setWorkspaceError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex flex-col space-y-2">
+                  <Label>Role</Label>
+                  <select
+                    name="invitedMemberRole"
+                    className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    value={invitedMemberRole}
+                    onChange={(event) => {
+                      setInvitedMemberRole(
+                        event.target.value as "ADMIN" | "USER",
+                      );
+                      setWorkspaceError(null);
+                    }}
+                  >
+                    <option value="USER">User</option>
+                    <option value="ADMIN">Admin</option>
+                  </select>
+                </div>
+              </div>
               {workspaceError ? (
                 <DialogDescription className="text-sm text-red-500">
                   {workspaceError}
@@ -363,6 +425,8 @@ export function Mail({
 
                     const accountName = emailAccountName.trim();
                     const accountEmail = emailAccountEmail.trim();
+                    const inviteName = invitedMemberName.trim();
+                    const inviteEmail = invitedMemberEmail.trim();
                     if (accountName && !accountEmail) {
                       setWorkspaceError("Email account address is required.");
                       return;
@@ -372,6 +436,17 @@ export function Mail({
                       !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(accountEmail)
                     ) {
                       setWorkspaceError("Enter a valid email account address.");
+                      return;
+                    }
+                    if (inviteName && !inviteEmail) {
+                      setWorkspaceError("Invite email address is required.");
+                      return;
+                    }
+                    if (
+                      inviteEmail &&
+                      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inviteEmail)
+                    ) {
+                      setWorkspaceError("Enter a valid invite email address.");
                       return;
                     }
 
@@ -404,6 +479,15 @@ export function Mail({
                               },
                             ]
                           : undefined,
+                        invitedMembers: inviteEmail
+                          ? [
+                              {
+                                name: inviteName || undefined,
+                                email: inviteEmail,
+                                role: invitedMemberRole,
+                              },
+                            ]
+                          : undefined,
                       }),
                     });
 
@@ -417,6 +501,9 @@ export function Mail({
                     setWorkspaceName("");
                     setEmailAccountName("");
                     setEmailAccountEmail("");
+                    setInvitedMemberName("");
+                    setInvitedMemberEmail("");
+                    setInvitedMemberRole("USER");
                     setFile(undefined);
                     setIsUploading(false);
                     setCreateWorkspaceOpen(false);

--- a/apps/web/components/mail/components/mail.tsx
+++ b/apps/web/components/mail/components/mail.tsx
@@ -38,7 +38,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import {
   configAtom,
   openComposeAtom,
@@ -125,6 +125,10 @@ export function Mail({
   const [isCollapsed, setIsCollapsed] = React.useState(defaultCollapsed);
   const [file, setFile] = React.useState<File | undefined>();
   const [isUploading, setIsUploading] = React.useState(false);
+  const [workspaceName, setWorkspaceName] = React.useState("");
+  const [workspaceError, setWorkspaceError] = React.useState<string | null>(
+    null,
+  );
   const [selectedTab, setSelectedTab] = useAtom(tabAtom);
   const [composeOpen, setComposeOpen] = useAtom(openComposeAtom);
   const [stateThreadsData, setStateThreadsData] = useAtom(threadsAtom);
@@ -133,6 +137,7 @@ export function Mail({
   );
 
   const { edgestore } = useEdgeStore();
+  const { mutate } = useSWRConfig();
 
   const mail = useAtomValue(configAtom);
 
@@ -246,7 +251,7 @@ export function Mail({
         <WorkspaceSidebar />
         <Dialog
           open={createWorkspaceOpen}
-          onOpenChange={() => setCreateWorkspaceOpen(!createWorkspaceOpen)}
+          onOpenChange={setCreateWorkspaceOpen}
         >
           <DialogContent className="sm:max-w-[625px]">
             <DialogHeader>
@@ -267,12 +272,21 @@ export function Mail({
               </div>
               <div className="flex flex-col space-y-2">
                 <Label>Name</Label>
-                <Input type="text" name="name" />
+                <Input
+                  type="text"
+                  name="name"
+                  value={workspaceName}
+                  onChange={(event) => {
+                    setWorkspaceName(event.target.value);
+                    setWorkspaceError(null);
+                  }}
+                />
               </div>
-              <div className="flex flex-col space-y-2">
-                <Label>Description</Label>
-                <Input type="text" name="description" />
-              </div>
+              {workspaceError ? (
+                <DialogDescription className="text-sm text-red-500">
+                  {workspaceError}
+                </DialogDescription>
+              ) : null}
             </div>
             <DialogFooter>
               <div className="flex space-x-2">
@@ -284,8 +298,17 @@ export function Mail({
                 </Button>
                 <Button
                   onClick={async () => {
+                    const name = workspaceName.trim();
+                    if (!name) {
+                      setWorkspaceError("Workspace name is required.");
+                      return;
+                    }
+
+                    setWorkspaceError(null);
+                    setIsUploading(true);
+                    let image: string | undefined;
+
                     if (file) {
-                      setIsUploading(true);
                       const res = await edgestore.publicFiles.upload({
                         file,
                         onProgressChange: (progress) => {
@@ -293,14 +316,28 @@ export function Mail({
                           console.log(progress);
                         },
                       });
-                      // you can run some server action or api here
-                      // to add the necessary data to your database
-                      console.log(res);
+                      image = res.url;
                     }
 
+                    const response = await fetch("/api/workspaces", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ name, image }),
+                    });
+
+                    if (!response.ok) {
+                      setWorkspaceError("Could not create workspace.");
+                      setIsUploading(false);
+                      return;
+                    }
+
+                    await mutate("/api/workspaces");
+                    setWorkspaceName("");
+                    setFile(undefined);
                     setIsUploading(false);
                     setCreateWorkspaceOpen(false);
                   }}
+                  disabled={isUploading}
                 >
                   {isUploading ? (
                     <>

--- a/apps/web/components/mail/components/workspace-sidebar.tsx
+++ b/apps/web/components/mail/components/workspace-sidebar.tsx
@@ -19,7 +19,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { openCreateWorkspaceOpenAtom } from "@/utils/store";
 import { useSetAtom } from "jotai";
-import { Building2, Loader2, Mail, Plus, Save, Trash2 } from "lucide-react";
+import {
+  Building2,
+  Loader2,
+  Mail,
+  Plus,
+  Save,
+  Trash2,
+  UserPlus,
+} from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
 import * as React from "react";
 import useSWR from "swr";
@@ -30,11 +38,25 @@ type EmailAccount = {
   email: string;
 };
 
+type WorkspaceMember = {
+  id: string;
+  role: "OWNER" | "ADMIN" | "USER";
+  invitedName: string | null;
+  invitedEmail: string | null;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+  } | null;
+};
+
 type Workspace = {
   id: string;
   name: string;
   image: string | null;
   role: "OWNER" | "ADMIN" | "USER";
+  members: WorkspaceMember[];
   emailAccounts: EmailAccount[];
 };
 
@@ -45,6 +67,12 @@ type WorkspacesResponse = {
 type EmailAccountDraft = {
   name: string;
   email: string;
+};
+
+type MemberDraft = {
+  name: string;
+  email: string;
+  role: "ADMIN" | "USER";
 };
 
 const userNavigation = [
@@ -76,6 +104,16 @@ export function WorkspaceSidebar() {
   >(null);
   const [isSavingEmailAccount, setIsSavingEmailAccount] =
     React.useState(false);
+  const [memberDraft, setMemberDraft] = React.useState<MemberDraft>({
+    name: "",
+    email: "",
+    role: "USER",
+  });
+  const [editingMembers, setEditingMembers] = React.useState<
+    Record<string, { role: "ADMIN" | "USER" }>
+  >({});
+  const [memberError, setMemberError] = React.useState<string | null>(null);
+  const [isSavingMember, setIsSavingMember] = React.useState(false);
   const managingWorkspace =
     workspaces.find((workspace) => workspace.id === managingWorkspaceId) ??
     null;
@@ -96,8 +134,20 @@ export function WorkspaceSidebar() {
         ]),
       ),
     );
+    setEditingMembers(
+      Object.fromEntries(
+        managingWorkspace.members.map((member) => [
+          member.id,
+          {
+            role: member.role === "OWNER" ? "USER" : member.role,
+          },
+        ]),
+      ),
+    );
     setEmailAccountDraft({ name: "", email: "" });
+    setMemberDraft({ name: "", email: "", role: "USER" });
     setEmailAccountError(null);
+    setMemberError(null);
   }, [managingWorkspace]);
 
   const addEmailAccount = async () => {
@@ -143,6 +193,105 @@ export function WorkspaceSidebar() {
     }
 
     setEmailAccountDraft({ name: "", email: "" });
+    await mutate();
+  };
+
+  const addMember = async () => {
+    if (!managingWorkspace) {
+      return;
+    }
+
+    const name = memberDraft.name.trim();
+    const email = memberDraft.email.trim();
+    if (!email) {
+      setMemberError("Invite email address is required.");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setMemberError("Enter a valid invite email address.");
+      return;
+    }
+    if (
+      managingWorkspace.members.some(
+        (member) =>
+          getMemberEmail(member)?.toLowerCase() === email.toLowerCase(),
+      )
+    ) {
+      setMemberError("Member already belongs to this workspace.");
+      return;
+    }
+
+    setIsSavingMember(true);
+    setMemberError(null);
+    const response = await fetch(
+      `/api/workspaces/${managingWorkspace.id}/members`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name || undefined,
+          email,
+          role: memberDraft.role,
+        }),
+      },
+    );
+    setIsSavingMember(false);
+
+    if (!response.ok) {
+      setMemberError("Could not invite member.");
+      return;
+    }
+
+    setMemberDraft({ name: "", email: "", role: "USER" });
+    await mutate();
+  };
+
+  const updateMemberRole = async (member: WorkspaceMember) => {
+    if (!managingWorkspace || member.role === "OWNER") {
+      return;
+    }
+
+    const draft = editingMembers[member.id] ?? {
+      role: member.role === "OWNER" ? "USER" : member.role,
+    };
+    setIsSavingMember(true);
+    setMemberError(null);
+    const response = await fetch(
+      `/api/workspaces/${managingWorkspace.id}/members/${member.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: draft.role }),
+      },
+    );
+    setIsSavingMember(false);
+
+    if (!response.ok) {
+      setMemberError("Could not update member role.");
+      return;
+    }
+
+    await mutate();
+  };
+
+  const deleteMember = async (member: WorkspaceMember) => {
+    if (!managingWorkspace || member.role === "OWNER") {
+      return;
+    }
+
+    setIsSavingMember(true);
+    setMemberError(null);
+    const response = await fetch(
+      `/api/workspaces/${managingWorkspace.id}/members/${member.id}`,
+      { method: "DELETE" },
+    );
+    setIsSavingMember(false);
+
+    if (!response.ok) {
+      setMemberError("Could not remove member.");
+      return;
+    }
+
     await mutate();
   };
 
@@ -225,7 +374,7 @@ export function WorkspaceSidebar() {
               </Button>
             ) : workspaces.length > 0 ? (
               workspaces.map((workspace) => {
-                const canManageEmailAccounts =
+                const canManageWorkspace =
                   workspace.role === "OWNER" || workspace.role === "ADMIN";
 
                 return (
@@ -250,16 +399,16 @@ export function WorkspaceSidebar() {
                     >
                       <DropdownMenuLabel>{workspace.name}</DropdownMenuLabel>
                       <DropdownMenuItem
-                        disabled={!canManageEmailAccounts}
+                        disabled={!canManageWorkspace}
                         onSelect={(event) => {
                           event.preventDefault();
-                          if (canManageEmailAccounts) {
+                          if (canManageWorkspace) {
                             setManagingWorkspaceId(workspace.id);
                           }
                         }}
                       >
-                        <Mail className="mr-2 h-4 w-4" />
-                        Manage email accounts
+                        <UserPlus className="mr-2 h-4 w-4" />
+                        Manage workspace
                       </DropdownMenuItem>
                       {workspace.emailAccounts.length ? (
                         <>
@@ -331,144 +480,302 @@ export function WorkspaceSidebar() {
       >
         <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[640px]">
           <DialogHeader>
-            <DialogTitle>{managingWorkspace?.name} email accounts</DialogTitle>
+            <DialogTitle>{managingWorkspace?.name} workspace</DialogTitle>
             <DialogDescription>
-              Add Gmail or Google Workspace accounts that belong to this
-              workspace.
+              Manage team members and connected Gmail or Google Workspace
+              accounts.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
-            {managingWorkspace?.emailAccounts.length ? (
-              <div className="space-y-3">
-                {managingWorkspace.emailAccounts.map((emailAccount) => {
-                  const draft = editingEmailAccounts[emailAccount.id] ?? {
-                    name: emailAccount.name,
-                    email: emailAccount.email,
-                  };
+            <div className="space-y-3">
+              <div className="flex items-center space-x-2">
+                <UserPlus className="h-4 w-4" />
+                <DialogDescription>Team members</DialogDescription>
+              </div>
+              {managingWorkspace?.members.length ? (
+                <div className="space-y-3">
+                  {managingWorkspace.members.map((member) => {
+                    const draft = editingMembers[member.id] ?? {
+                      role: member.role === "OWNER" ? "USER" : member.role,
+                    };
+                    const canEditMember =
+                      managingWorkspace.role === "OWNER" &&
+                      member.role !== "OWNER";
 
-                  return (
-                    <div
-                      key={emailAccount.id}
-                      className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto_auto]"
-                    >
-                      <div className="flex flex-col space-y-2">
-                        <Label>Name</Label>
-                        <Input
-                          value={draft.name}
-                          onChange={(event) => {
-                            setEditingEmailAccounts((drafts) => ({
-                              ...drafts,
-                              [emailAccount.id]: {
-                                ...draft,
-                                name: event.target.value,
-                              },
-                            }));
-                            setEmailAccountError(null);
-                          }}
-                        />
+                    return (
+                      <div
+                        key={member.id}
+                        className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_120px_auto_auto]"
+                      >
+                        <div className="flex flex-col space-y-2">
+                          <Label>Name</Label>
+                          <Input value={getMemberName(member)} disabled />
+                        </div>
+                        <div className="flex flex-col space-y-2">
+                          <Label>Email</Label>
+                          <Input value={getMemberEmail(member) ?? ""} disabled />
+                        </div>
+                        <div className="flex flex-col space-y-2">
+                          <Label>Role</Label>
+                          <select
+                            className="h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+                            value={member.role === "OWNER" ? "OWNER" : draft.role}
+                            disabled={!canEditMember || isSavingMember}
+                            onChange={(event) => {
+                              setEditingMembers((drafts) => ({
+                                ...drafts,
+                                [member.id]: {
+                                  role: event.target.value as "ADMIN" | "USER",
+                                },
+                              }));
+                              setMemberError(null);
+                            }}
+                          >
+                            {member.role === "OWNER" ? (
+                              <option value="OWNER">Owner</option>
+                            ) : null}
+                            <option value="USER">User</option>
+                            <option value="ADMIN">Admin</option>
+                          </select>
+                        </div>
+                        <div className="flex items-end">
+                          <Button
+                            size="icon"
+                            variant="secondary"
+                            disabled={!canEditMember || isSavingMember}
+                            onClick={() => updateMemberRole(member)}
+                          >
+                            <Save className="h-4 w-4" />
+                            <span className="sr-only">Save member role</span>
+                          </Button>
+                        </div>
+                        <div className="flex items-end">
+                          <Button
+                            size="icon"
+                            variant="secondary"
+                            disabled={!canEditMember || isSavingMember}
+                            onClick={() => deleteMember(member)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                            <span className="sr-only">Remove member</span>
+                          </Button>
+                        </div>
                       </div>
-                      <div className="flex flex-col space-y-2">
-                        <Label>Email</Label>
-                        <Input
-                          type="email"
-                          value={draft.email}
-                          onChange={(event) => {
-                            setEditingEmailAccounts((drafts) => ({
-                              ...drafts,
-                              [emailAccount.id]: {
-                                ...draft,
-                                email: event.target.value,
-                              },
-                            }));
-                            setEmailAccountError(null);
-                          }}
-                        />
-                      </div>
-                      <div className="flex items-end">
-                        <Button
-                          size="icon"
-                          variant="secondary"
-                          disabled={isSavingEmailAccount}
-                          onClick={() => updateEmailAccount(emailAccount)}
-                        >
-                          <Save className="h-4 w-4" />
-                          <span className="sr-only">Save email account</span>
-                        </Button>
-                      </div>
-                      <div className="flex items-end">
-                        <Button
-                          size="icon"
-                          variant="secondary"
-                          disabled={isSavingEmailAccount}
-                          onClick={() => deleteEmailAccount(emailAccount)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                          <span className="sr-only">Remove email account</span>
-                        </Button>
-                      </div>
-                    </div>
-                  );
-                })}
+                    );
+                  })}
+                </div>
+              ) : null}
+              <div className="grid grid-cols-1 gap-3 border-t pt-4 sm:grid-cols-[1fr_1fr_120px_auto]">
+                <div className="flex flex-col space-y-2">
+                  <Label>Invite name</Label>
+                  <Input
+                    placeholder="Alex Morgan"
+                    value={memberDraft.name}
+                    onChange={(event) => {
+                      setMemberDraft((draft) => ({
+                        ...draft,
+                        name: event.target.value,
+                      }));
+                      setMemberError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex flex-col space-y-2">
+                  <Label>Invite email</Label>
+                  <Input
+                    type="email"
+                    placeholder="alex@example.com"
+                    value={memberDraft.email}
+                    onChange={(event) => {
+                      setMemberDraft((draft) => ({
+                        ...draft,
+                        email: event.target.value,
+                      }));
+                      setMemberError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex flex-col space-y-2">
+                  <Label>Role</Label>
+                  <select
+                    className="h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm"
+                    value={memberDraft.role}
+                    onChange={(event) => {
+                      setMemberDraft((draft) => ({
+                        ...draft,
+                        role: event.target.value as "ADMIN" | "USER",
+                      }));
+                      setMemberError(null);
+                    }}
+                  >
+                    <option value="USER">User</option>
+                    <option value="ADMIN">Admin</option>
+                  </select>
+                </div>
+                <div className="flex items-end">
+                  <Button
+                    variant="secondary"
+                    disabled={isSavingMember}
+                    onClick={addMember}
+                  >
+                    <Plus className="mr-2 h-4 w-4" />
+                    Invite
+                  </Button>
+                </div>
               </div>
-            ) : (
-              <DialogDescription>
-                This workspace does not have email accounts yet.
-              </DialogDescription>
-            )}
-            <div className="grid grid-cols-1 gap-3 border-t pt-4 sm:grid-cols-[1fr_1fr_auto]">
-              <div className="flex flex-col space-y-2">
-                <Label>New account name</Label>
-                <Input
-                  placeholder="Support inbox"
-                  value={emailAccountDraft.name}
-                  onChange={(event) => {
-                    setEmailAccountDraft((draft) => ({
-                      ...draft,
-                      name: event.target.value,
-                    }));
-                    setEmailAccountError(null);
-                  }}
-                />
-              </div>
-              <div className="flex flex-col space-y-2">
-                <Label>New account email</Label>
-                <Input
-                  type="email"
-                  placeholder="support@example.com"
-                  value={emailAccountDraft.email}
-                  onChange={(event) => {
-                    setEmailAccountDraft((draft) => ({
-                      ...draft,
-                      email: event.target.value,
-                    }));
-                    setEmailAccountError(null);
-                  }}
-                />
-              </div>
-              <div className="flex items-end">
-                <Button
-                  variant="secondary"
-                  disabled={
-                    isSavingEmailAccount ||
-                    (managingWorkspace?.emailAccounts.length ?? 0) >= 10
-                  }
-                  onClick={addEmailAccount}
-                >
-                  <Plus className="mr-2 h-4 w-4" />
-                  Add
-                </Button>
-              </div>
+              {memberError ? (
+                <DialogDescription className="text-red-500">
+                  {memberError}
+                </DialogDescription>
+              ) : null}
             </div>
-            {emailAccountError ? (
-              <DialogDescription className="text-red-500">
-                {emailAccountError}
-              </DialogDescription>
-            ) : null}
+            <div className="space-y-3 border-t pt-4">
+              <div className="flex items-center space-x-2">
+                <Mail className="h-4 w-4" />
+                <DialogDescription>Email accounts</DialogDescription>
+              </div>
+              {managingWorkspace?.emailAccounts.length ? (
+                <div className="space-y-3">
+                  {managingWorkspace.emailAccounts.map((emailAccount) => {
+                    const draft = editingEmailAccounts[emailAccount.id] ?? {
+                      name: emailAccount.name,
+                      email: emailAccount.email,
+                    };
+
+                    return (
+                      <div
+                        key={emailAccount.id}
+                        className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto_auto]"
+                      >
+                        <div className="flex flex-col space-y-2">
+                          <Label>Name</Label>
+                          <Input
+                            value={draft.name}
+                            onChange={(event) => {
+                              setEditingEmailAccounts((drafts) => ({
+                                ...drafts,
+                                [emailAccount.id]: {
+                                  ...draft,
+                                  name: event.target.value,
+                                },
+                              }));
+                              setEmailAccountError(null);
+                            }}
+                          />
+                        </div>
+                        <div className="flex flex-col space-y-2">
+                          <Label>Email</Label>
+                          <Input
+                            type="email"
+                            value={draft.email}
+                            onChange={(event) => {
+                              setEditingEmailAccounts((drafts) => ({
+                                ...drafts,
+                                [emailAccount.id]: {
+                                  ...draft,
+                                  email: event.target.value,
+                                },
+                              }));
+                              setEmailAccountError(null);
+                            }}
+                          />
+                        </div>
+                        <div className="flex items-end">
+                          <Button
+                            size="icon"
+                            variant="secondary"
+                            disabled={isSavingEmailAccount}
+                            onClick={() => updateEmailAccount(emailAccount)}
+                          >
+                            <Save className="h-4 w-4" />
+                            <span className="sr-only">Save email account</span>
+                          </Button>
+                        </div>
+                        <div className="flex items-end">
+                          <Button
+                            size="icon"
+                            variant="secondary"
+                            disabled={isSavingEmailAccount}
+                            onClick={() => deleteEmailAccount(emailAccount)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                            <span className="sr-only">
+                              Remove email account
+                            </span>
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <DialogDescription>
+                  This workspace does not have email accounts yet.
+                </DialogDescription>
+              )}
+              <div className="grid grid-cols-1 gap-3 border-t pt-4 sm:grid-cols-[1fr_1fr_auto]">
+                <div className="flex flex-col space-y-2">
+                  <Label>New account name</Label>
+                  <Input
+                    placeholder="Support inbox"
+                    value={emailAccountDraft.name}
+                    onChange={(event) => {
+                      setEmailAccountDraft((draft) => ({
+                        ...draft,
+                        name: event.target.value,
+                      }));
+                      setEmailAccountError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex flex-col space-y-2">
+                  <Label>New account email</Label>
+                  <Input
+                    type="email"
+                    placeholder="support@example.com"
+                    value={emailAccountDraft.email}
+                    onChange={(event) => {
+                      setEmailAccountDraft((draft) => ({
+                        ...draft,
+                        email: event.target.value,
+                      }));
+                      setEmailAccountError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex items-end">
+                  <Button
+                    variant="secondary"
+                    disabled={
+                      isSavingEmailAccount ||
+                      (managingWorkspace?.emailAccounts.length ?? 0) >= 10
+                    }
+                    onClick={addEmailAccount}
+                  >
+                    <Plus className="mr-2 h-4 w-4" />
+                    Add
+                  </Button>
+                </div>
+              </div>
+              {emailAccountError ? (
+                <DialogDescription className="text-red-500">
+                  {emailAccountError}
+                </DialogDescription>
+              ) : null}
+            </div>
           </div>
         </DialogContent>
       </Dialog>
     </>
   );
+}
+
+function getMemberName(member: WorkspaceMember) {
+  return member.user?.name || member.invitedName || "Pending invite";
+}
+
+function getMemberEmail(member: WorkspaceMember) {
+  return member.user?.email || member.invitedEmail;
 }
 
 function getWorkspaceInitials(name: string) {

--- a/apps/web/components/mail/components/workspace-sidebar.tsx
+++ b/apps/web/components/mail/components/workspace-sidebar.tsx
@@ -1,25 +1,50 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { openCreateWorkspaceOpenAtom } from "@/utils/store";
 import { useSetAtom } from "jotai";
-import { Building2, Loader2, Plus } from "lucide-react";
+import { Building2, Loader2, Mail, Plus, Save, Trash2 } from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
+import * as React from "react";
 import useSWR from "swr";
+
+type EmailAccount = {
+  id: string;
+  name: string;
+  email: string;
+};
 
 type Workspace = {
   id: string;
   name: string;
   image: string | null;
+  role: "OWNER" | "ADMIN" | "USER";
+  emailAccounts: EmailAccount[];
 };
 
 type WorkspacesResponse = {
   workspaces: Workspace[];
+};
+
+type EmailAccountDraft = {
+  name: string;
+  email: string;
 };
 
 const userNavigation = [
@@ -34,76 +59,415 @@ const userNavigation = [
 export function WorkspaceSidebar() {
   const { data: session, status } = useSession();
   const setCreateWorkspaceOpen = useSetAtom(openCreateWorkspaceOpenAtom);
-  const { data, isLoading } = useSWR<WorkspacesResponse>(
+  const { data, isLoading, mutate } = useSWR<WorkspacesResponse>(
     status === "authenticated" ? "/api/workspaces" : null,
   );
   const workspaces = data?.workspaces ?? [];
+  const [managingWorkspaceId, setManagingWorkspaceId] = React.useState<
+    string | null
+  >(null);
+  const [emailAccountDraft, setEmailAccountDraft] =
+    React.useState<EmailAccountDraft>({ name: "", email: "" });
+  const [editingEmailAccounts, setEditingEmailAccounts] = React.useState<
+    Record<string, EmailAccountDraft>
+  >({});
+  const [emailAccountError, setEmailAccountError] = React.useState<
+    string | null
+  >(null);
+  const [isSavingEmailAccount, setIsSavingEmailAccount] =
+    React.useState(false);
+  const managingWorkspace =
+    workspaces.find((workspace) => workspace.id === managingWorkspaceId) ??
+    null;
+
+  React.useEffect(() => {
+    if (!managingWorkspace) {
+      return;
+    }
+
+    setEditingEmailAccounts(
+      Object.fromEntries(
+        managingWorkspace.emailAccounts.map((emailAccount) => [
+          emailAccount.id,
+          {
+            name: emailAccount.name,
+            email: emailAccount.email,
+          },
+        ]),
+      ),
+    );
+    setEmailAccountDraft({ name: "", email: "" });
+    setEmailAccountError(null);
+  }, [managingWorkspace]);
+
+  const addEmailAccount = async () => {
+    if (!managingWorkspace) {
+      return;
+    }
+
+    const name = emailAccountDraft.name.trim();
+    const email = emailAccountDraft.email.trim();
+    if (!name || !email) {
+      setEmailAccountError("Name and email address are required.");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailAccountError("Enter a valid email account address.");
+      return;
+    }
+    if (
+      managingWorkspace.emailAccounts.some(
+        (emailAccount) =>
+          emailAccount.email.toLowerCase() === email.toLowerCase(),
+      )
+    ) {
+      setEmailAccountError("Email account already exists in this workspace.");
+      return;
+    }
+
+    setIsSavingEmailAccount(true);
+    setEmailAccountError(null);
+    const response = await fetch(
+      `/api/workspaces/${managingWorkspace.id}/email-accounts`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email }),
+      },
+    );
+    setIsSavingEmailAccount(false);
+
+    if (!response.ok) {
+      setEmailAccountError("Could not add email account.");
+      return;
+    }
+
+    setEmailAccountDraft({ name: "", email: "" });
+    await mutate();
+  };
+
+  const updateEmailAccount = async (emailAccount: EmailAccount) => {
+    if (!managingWorkspace) {
+      return;
+    }
+
+    const draft = editingEmailAccounts[emailAccount.id] ?? emailAccount;
+    const name = draft.name.trim();
+    const email = draft.email.trim();
+    if (!name || !email) {
+      setEmailAccountError("Name and email address are required.");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailAccountError("Enter a valid email account address.");
+      return;
+    }
+    if (
+      managingWorkspace.emailAccounts.some(
+        (account) =>
+          account.id !== emailAccount.id &&
+          account.email.toLowerCase() === email.toLowerCase(),
+      )
+    ) {
+      setEmailAccountError("Email account already exists in this workspace.");
+      return;
+    }
+
+    setIsSavingEmailAccount(true);
+    setEmailAccountError(null);
+    const response = await fetch(
+      `/api/workspaces/${managingWorkspace.id}/email-accounts/${emailAccount.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email }),
+      },
+    );
+    setIsSavingEmailAccount(false);
+
+    if (!response.ok) {
+      setEmailAccountError("Could not update email account.");
+      return;
+    }
+
+    await mutate();
+  };
+
+  const deleteEmailAccount = async (emailAccount: EmailAccount) => {
+    if (!managingWorkspace) {
+      return;
+    }
+
+    setIsSavingEmailAccount(true);
+    setEmailAccountError(null);
+    const response = await fetch(
+      `/api/workspaces/${managingWorkspace.id}/email-accounts/${emailAccount.id}`,
+      { method: "DELETE" },
+    );
+    setIsSavingEmailAccount(false);
+
+    if (!response.ok) {
+      setEmailAccountError("Could not remove email account.");
+      return;
+    }
+
+    await mutate();
+  };
 
   return (
-    <div className="left-0 top-0 h-screen w-16 flex-col items-center justify-between space-y-2 border-r">
-      <div className="flex h-full flex-col justify-between">
-        <div className="flex flex-col items-center space-y-4 p-2">
-          {isLoading ? (
-            <Button className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/60">
-              <Loader2 className="h-5 w-5 animate-spin text-background" />
-            </Button>
-          ) : workspaces.length > 0 ? (
-            workspaces.map((workspace) => (
-              <Button
-                key={workspace.id}
-                title={workspace.name}
-                className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/80 p-0"
-              >
-                <Avatar className="h-full w-full rounded-xl">
-                  <AvatarImage src={workspace.image || undefined} />
-                  <AvatarFallback className="rounded-xl bg-foreground/80 font-cal text-xl font-semibold text-background">
-                    {getWorkspaceInitials(workspace.name)}
-                  </AvatarFallback>
-                </Avatar>
+    <>
+      <div className="left-0 top-0 h-screen w-16 flex-col items-center justify-between space-y-2 border-r">
+        <div className="flex h-full flex-col justify-between">
+          <div className="flex flex-col items-center space-y-4 p-2">
+            {isLoading ? (
+              <Button className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/60">
+                <Loader2 className="h-5 w-5 animate-spin text-background" />
               </Button>
-            ))
-          ) : (
-            <Button className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/60">
-              <Building2 className="h-5 w-5 text-background" />
-            </Button>
-          )}
-          <Button
-            onClick={(e) => {
-              e.preventDefault();
-              setCreateWorkspaceOpen(true);
-            }}
-            className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground font-cal text-xl font-semibold"
-          >
-            <Plus className="h-8 w-8 text-background" />
-          </Button>
-        </div>
+            ) : workspaces.length > 0 ? (
+              workspaces.map((workspace) => {
+                const canManageEmailAccounts =
+                  workspace.role === "OWNER" || workspace.role === "ADMIN";
 
-        {session && session.user && (
-          <div className="flex w-full flex-col items-center pb-4">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Avatar className="cursor-pointer">
-                  <AvatarImage src={session?.user.image || undefined} />
-                  <AvatarFallback>
-                    {session?.user.name ? session.user.name[0] : ""}
-                  </AvatarFallback>
-                </Avatar>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-[160px]">
-                <DropdownMenuItem>{session.user.email}</DropdownMenuItem>
-                {userNavigation.map((item) => (
-                  <DropdownMenuItem key={item.name}>
-                    <a href={item.href} onClick={item.onClick}>
-                      {item.name}
-                    </a>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+                return (
+                  <DropdownMenu key={workspace.id}>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        title={workspace.name}
+                        className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/80 p-0"
+                      >
+                        <Avatar className="h-full w-full rounded-xl">
+                          <AvatarImage src={workspace.image || undefined} />
+                          <AvatarFallback className="rounded-xl bg-foreground/80 font-cal text-xl font-semibold text-background">
+                            {getWorkspaceInitials(workspace.name)}
+                          </AvatarFallback>
+                        </Avatar>
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="start"
+                      side="right"
+                      className="w-56"
+                    >
+                      <DropdownMenuLabel>{workspace.name}</DropdownMenuLabel>
+                      <DropdownMenuItem
+                        disabled={!canManageEmailAccounts}
+                        onSelect={(event) => {
+                          event.preventDefault();
+                          if (canManageEmailAccounts) {
+                            setManagingWorkspaceId(workspace.id);
+                          }
+                        }}
+                      >
+                        <Mail className="mr-2 h-4 w-4" />
+                        Manage email accounts
+                      </DropdownMenuItem>
+                      {workspace.emailAccounts.length ? (
+                        <>
+                          <DropdownMenuSeparator />
+                          {workspace.emailAccounts.slice(0, 3).map((account) => (
+                            <DropdownMenuItem
+                              key={account.id}
+                              disabled
+                              className="block truncate"
+                            >
+                              {account.email}
+                            </DropdownMenuItem>
+                          ))}
+                        </>
+                      ) : null}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                );
+              })
+            ) : (
+              <Button className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/60">
+                <Building2 className="h-5 w-5 text-background" />
+              </Button>
+            )}
+            <Button
+              onClick={(e) => {
+                e.preventDefault();
+                setCreateWorkspaceOpen(true);
+              }}
+              className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground font-cal text-xl font-semibold"
+            >
+              <Plus className="h-8 w-8 text-background" />
+            </Button>
           </div>
-        )}
+
+          {session && session.user && (
+            <div className="flex w-full flex-col items-center pb-4">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Avatar className="cursor-pointer">
+                    <AvatarImage src={session?.user.image || undefined} />
+                    <AvatarFallback>
+                      {session?.user.name ? session.user.name[0] : ""}
+                    </AvatarFallback>
+                  </Avatar>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-[160px]">
+                  <DropdownMenuItem>{session.user.email}</DropdownMenuItem>
+                  {userNavigation.map((item) => (
+                    <DropdownMenuItem key={item.name}>
+                      <a href={item.href} onClick={item.onClick}>
+                        {item.name}
+                      </a>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+      <Dialog
+        open={!!managingWorkspace}
+        onOpenChange={(open) => {
+          if (!open) {
+            setManagingWorkspaceId(null);
+          }
+        }}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[640px]">
+          <DialogHeader>
+            <DialogTitle>{managingWorkspace?.name} email accounts</DialogTitle>
+            <DialogDescription>
+              Add Gmail or Google Workspace accounts that belong to this
+              workspace.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            {managingWorkspace?.emailAccounts.length ? (
+              <div className="space-y-3">
+                {managingWorkspace.emailAccounts.map((emailAccount) => {
+                  const draft = editingEmailAccounts[emailAccount.id] ?? {
+                    name: emailAccount.name,
+                    email: emailAccount.email,
+                  };
+
+                  return (
+                    <div
+                      key={emailAccount.id}
+                      className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto_auto]"
+                    >
+                      <div className="flex flex-col space-y-2">
+                        <Label>Name</Label>
+                        <Input
+                          value={draft.name}
+                          onChange={(event) => {
+                            setEditingEmailAccounts((drafts) => ({
+                              ...drafts,
+                              [emailAccount.id]: {
+                                ...draft,
+                                name: event.target.value,
+                              },
+                            }));
+                            setEmailAccountError(null);
+                          }}
+                        />
+                      </div>
+                      <div className="flex flex-col space-y-2">
+                        <Label>Email</Label>
+                        <Input
+                          type="email"
+                          value={draft.email}
+                          onChange={(event) => {
+                            setEditingEmailAccounts((drafts) => ({
+                              ...drafts,
+                              [emailAccount.id]: {
+                                ...draft,
+                                email: event.target.value,
+                              },
+                            }));
+                            setEmailAccountError(null);
+                          }}
+                        />
+                      </div>
+                      <div className="flex items-end">
+                        <Button
+                          size="icon"
+                          variant="secondary"
+                          disabled={isSavingEmailAccount}
+                          onClick={() => updateEmailAccount(emailAccount)}
+                        >
+                          <Save className="h-4 w-4" />
+                          <span className="sr-only">Save email account</span>
+                        </Button>
+                      </div>
+                      <div className="flex items-end">
+                        <Button
+                          size="icon"
+                          variant="secondary"
+                          disabled={isSavingEmailAccount}
+                          onClick={() => deleteEmailAccount(emailAccount)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                          <span className="sr-only">Remove email account</span>
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <DialogDescription>
+                This workspace does not have email accounts yet.
+              </DialogDescription>
+            )}
+            <div className="grid grid-cols-1 gap-3 border-t pt-4 sm:grid-cols-[1fr_1fr_auto]">
+              <div className="flex flex-col space-y-2">
+                <Label>New account name</Label>
+                <Input
+                  placeholder="Support inbox"
+                  value={emailAccountDraft.name}
+                  onChange={(event) => {
+                    setEmailAccountDraft((draft) => ({
+                      ...draft,
+                      name: event.target.value,
+                    }));
+                    setEmailAccountError(null);
+                  }}
+                />
+              </div>
+              <div className="flex flex-col space-y-2">
+                <Label>New account email</Label>
+                <Input
+                  type="email"
+                  placeholder="support@example.com"
+                  value={emailAccountDraft.email}
+                  onChange={(event) => {
+                    setEmailAccountDraft((draft) => ({
+                      ...draft,
+                      email: event.target.value,
+                    }));
+                    setEmailAccountError(null);
+                  }}
+                />
+              </div>
+              <div className="flex items-end">
+                <Button
+                  variant="secondary"
+                  disabled={
+                    isSavingEmailAccount ||
+                    (managingWorkspace?.emailAccounts.length ?? 0) >= 10
+                  }
+                  onClick={addEmailAccount}
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add
+                </Button>
+              </div>
+            </div>
+            {emailAccountError ? (
+              <DialogDescription className="text-red-500">
+                {emailAccountError}
+              </DialogDescription>
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/apps/web/components/mail/components/workspace-sidebar.tsx
+++ b/apps/web/components/mail/components/workspace-sidebar.tsx
@@ -69,6 +69,11 @@ type EmailAccountDraft = {
   email: string;
 };
 
+type WorkspaceDraft = {
+  name: string;
+  image: string;
+};
+
 type MemberDraft = {
   name: string;
   email: string;
@@ -104,6 +109,12 @@ export function WorkspaceSidebar() {
   >(null);
   const [isSavingEmailAccount, setIsSavingEmailAccount] =
     React.useState(false);
+  const [workspaceDraft, setWorkspaceDraft] =
+    React.useState<WorkspaceDraft>({ name: "", image: "" });
+  const [workspaceError, setWorkspaceError] = React.useState<string | null>(
+    null,
+  );
+  const [isSavingWorkspace, setIsSavingWorkspace] = React.useState(false);
   const [memberDraft, setMemberDraft] = React.useState<MemberDraft>({
     name: "",
     email: "",
@@ -134,6 +145,10 @@ export function WorkspaceSidebar() {
         ]),
       ),
     );
+    setWorkspaceDraft({
+      name: managingWorkspace.name,
+      image: managingWorkspace.image ?? "",
+    });
     setEditingMembers(
       Object.fromEntries(
         managingWorkspace.members.map((member) => [
@@ -146,9 +161,47 @@ export function WorkspaceSidebar() {
     );
     setEmailAccountDraft({ name: "", email: "" });
     setMemberDraft({ name: "", email: "", role: "USER" });
+    setWorkspaceError(null);
     setEmailAccountError(null);
     setMemberError(null);
   }, [managingWorkspace]);
+
+  const updateWorkspace = async () => {
+    if (!managingWorkspace) {
+      return;
+    }
+
+    const name = workspaceDraft.name.trim();
+    const image = workspaceDraft.image.trim();
+    if (!name) {
+      setWorkspaceError("Workspace name is required.");
+      return;
+    }
+    if (image) {
+      try {
+        new URL(image);
+      } catch {
+        setWorkspaceError("Enter a valid workspace image URL.");
+        return;
+      }
+    }
+
+    setIsSavingWorkspace(true);
+    setWorkspaceError(null);
+    const response = await fetch(`/api/workspaces/${managingWorkspace.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, image: image || null }),
+    });
+    setIsSavingWorkspace(false);
+
+    if (!response.ok) {
+      setWorkspaceError("Could not update workspace details.");
+      return;
+    }
+
+    await mutate();
+  };
 
   const addEmailAccount = async () => {
     if (!managingWorkspace) {
@@ -487,6 +540,57 @@ export function WorkspaceSidebar() {
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
+            <div className="space-y-3">
+              <div className="flex items-center space-x-2">
+                <Building2 className="h-4 w-4" />
+                <DialogDescription>Workspace details</DialogDescription>
+              </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto]">
+                <div className="flex flex-col space-y-2">
+                  <Label>Name</Label>
+                  <Input
+                    value={workspaceDraft.name}
+                    onChange={(event) => {
+                      setWorkspaceDraft((draft) => ({
+                        ...draft,
+                        name: event.target.value,
+                      }));
+                      setWorkspaceError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex flex-col space-y-2">
+                  <Label>Logo URL</Label>
+                  <Input
+                    placeholder="https://example.com/logo.png"
+                    value={workspaceDraft.image}
+                    onChange={(event) => {
+                      setWorkspaceDraft((draft) => ({
+                        ...draft,
+                        image: event.target.value,
+                      }));
+                      setWorkspaceError(null);
+                    }}
+                  />
+                </div>
+                <div className="flex items-end">
+                  <Button
+                    size="icon"
+                    variant="secondary"
+                    disabled={isSavingWorkspace}
+                    onClick={updateWorkspace}
+                  >
+                    <Save className="h-4 w-4" />
+                    <span className="sr-only">Save workspace details</span>
+                  </Button>
+                </div>
+              </div>
+              {workspaceError ? (
+                <DialogDescription className="text-red-500">
+                  {workspaceError}
+                </DialogDescription>
+              ) : null}
+            </div>
             <div className="space-y-3">
               <div className="flex items-center space-x-2">
                 <UserPlus className="h-4 w-4" />

--- a/apps/web/components/mail/components/workspace-sidebar.tsx
+++ b/apps/web/components/mail/components/workspace-sidebar.tsx
@@ -8,9 +8,19 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { openCreateWorkspaceOpenAtom } from "@/utils/store";
 import { useSetAtom } from "jotai";
-import { Plus } from "lucide-react";
+import { Building2, Loader2, Plus } from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
-import Image from "next/image";
+import useSWR from "swr";
+
+type Workspace = {
+  id: string;
+  name: string;
+  image: string | null;
+};
+
+type WorkspacesResponse = {
+  workspaces: Workspace[];
+};
 
 const userNavigation = [
   { name: "Usage", href: "/usage" },
@@ -24,21 +34,39 @@ const userNavigation = [
 export function WorkspaceSidebar() {
   const { data: session, status } = useSession();
   const setCreateWorkspaceOpen = useSetAtom(openCreateWorkspaceOpenAtom);
+  const { data, isLoading } = useSWR<WorkspacesResponse>(
+    status === "authenticated" ? "/api/workspaces" : null,
+  );
+  const workspaces = data?.workspaces ?? [];
+
   return (
     <div className="left-0 top-0 h-screen w-16 flex-col items-center justify-between space-y-2 border-r">
       <div className="flex h-full flex-col justify-between">
         <div className="flex flex-col items-center space-y-4 p-2">
-          <Button className="relative flex h-12 w-full items-center justify-center rounded-xl bg-foreground/60 font-cal text-xl font-semibold text-white">
-            <Image
-              src="https://github.com/jeremyscatigna.png"
-              fill={true}
-              alt="Workspace"
-              className="rounded-xl"
-            />
-          </Button>
-          <Button className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/80 font-cal text-xl font-semibold text-white">
-            JS
-          </Button>
+          {isLoading ? (
+            <Button className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/60">
+              <Loader2 className="h-5 w-5 animate-spin text-background" />
+            </Button>
+          ) : workspaces.length > 0 ? (
+            workspaces.map((workspace) => (
+              <Button
+                key={workspace.id}
+                title={workspace.name}
+                className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/80 p-0"
+              >
+                <Avatar className="h-full w-full rounded-xl">
+                  <AvatarImage src={workspace.image || undefined} />
+                  <AvatarFallback className="rounded-xl bg-foreground/80 font-cal text-xl font-semibold text-background">
+                    {getWorkspaceInitials(workspace.name)}
+                  </AvatarFallback>
+                </Avatar>
+              </Button>
+            ))
+          ) : (
+            <Button className="flex h-12 w-full items-center justify-center rounded-xl bg-foreground/60">
+              <Building2 className="h-5 w-5 text-background" />
+            </Button>
+          )}
           <Button
             onClick={(e) => {
               e.preventDefault();
@@ -77,4 +105,16 @@ export function WorkspaceSidebar() {
       </div>
     </div>
   );
+}
+
+function getWorkspaceInitials(name: string) {
+  const initials = name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+
+  return initials || "WS";
 }


### PR DESCRIPTION
## Description

This PR wires the existing workspace UI into the database-backed organization models so newly created workspaces are persisted and shown in the mail workspace sidebar.

It adds an authenticated /api/workspaces route for listing the current user's workspaces and creating a new OWNER membership, then updates the Create Workspace dialog to POST real workspace data and refresh the sidebar.

## What type of PR is this? (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Chore (Release)
- [ ] Revert

## Related Tickets & Documents

Refs #1

## Mobile & Desktop Screenshots/Recordings

No screenshots; backend/API wiring plus existing sidebar/dialog behavior.

## Steps to QA

1. Sign in and open the mail app.
2. Click the plus button in the workspace sidebar.
3. Enter a workspace name and create it.
4. Confirm the workspace persists through /api/workspaces and appears in the sidebar.

## Added to documentation?

- [ ] README.md
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

None.

## [optional] What gif best describes this PR or how it makes you feel?

A small but real first brick for teams/workspaces support.
